### PR TITLE
Fix starting puma server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   api-server:
     build:
       context: https://github.com/flaminestone/palladium-api.git
-    command: ["puma"]
+    command: ["bundle", "exec", "puma -C config/puma.rb"]
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
Old variant cause
```
ERROR: for api-server  Cannot start service api-server: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "puma": executable file not found in $PATH: unknown
```