### PR TITLE
Fix db failure by increasing `shm` size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - JWT_ISSUER=
   db:
     image: postgres
+    shm_size: 1gb
     volumes:
         - db:/var/lib/postgresql/data
   clientside-build:


### PR DESCRIPTION
Failures was like this in db logs:
```
2021-08-31 12:03:00.204 UTC [10461] ERROR:  could not resize shared memory segment "/PostgreSQL.653913738" to 2097152 bytes: No space left on device
```
But there is was enough space on server
This is memory failure