### PR TITLE
Fix empty db container init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     restart: always
     volumes:
         - db:/var/lib/postgresql/data
+    environment: 
+      POSTGRES_HOST_AUTH_METHOD: "trust"
   clientside-build:
     build:
       context: https://github.com/flaminestone/palladium-view.git


### PR DESCRIPTION
Since some version of postgresql container (defenetly newer than 11.3)
This option is required to correctly start of container

Without it it show error message:
```
Error: Database is uninitialized and superuser password is not specified.
You must specify POSTGRES_PASSWORD for the superuser. Use
"-e POSTGRES_PASSWORD=password" to set it in "docker run".

You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
without a password. This is *not* recommended. See PostgreSQL
documentation about "trust":
https://www.postgresql.org/docs/current/auth-trust.html
```