### PR TITLE
docker-compose command is not needed any more

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
   api-server:
     build:
       context: https://github.com/flaminestone/palladium-api.git
-    command: ["bundle", "exec", "puma -C config/puma.rb"]
     restart: always
     depends_on:
       - db


### PR DESCRIPTION
Since:
https://github.com/flaminestone/palladium-api/pull/151